### PR TITLE
Fix makefile. Add new line after the hello message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ -g hello.cc
+	g++ -g hello.cpp -o hello.out

--- a/hello.cpp
+++ b/hello.cpp
@@ -1,9 +1,10 @@
 #include <iostream>
 
-using namespace std;
+using std::cout;
+using std::endl;
 
 int main()
 {
-    cout << "Hello, World!";
+    cout << "Hello, World!" << endl;
     return 0;
 }


### PR DESCRIPTION
Fixes wrong source name in the makefile.
Adds new line after `Hello, World!` message.
Imports only `cout` and `endl` from `std` namespace.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>