### PR TITLE
chore: add missing extensions for c++ development

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "eclipse-cdt.cdt-vscode"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "eclipse-cdt.cdt-gdb-vscode"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Removes
- deprecated `eclipse-cdt.cdt-vscode` extension from recommendations

Adds
- `llvm-vs-code-extensions.vscode-clangd` extension to launch c/c++ language server
- `eclipse-cdt.cdt-gdb-vscode` extension that makes it possible to debug the project 

Solves https://github.com/eclipse/che/issues/21644