### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       memoryLimit: 1G
       mountSources: true
 commands:


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

Related issue: https://github.com/eclipse/che/issues/21979

![Screenshot from 2023-03-21 14-29-49](https://user-images.githubusercontent.com/1271546/226606408-e07572f0-1f3b-403d-8b6a-070175a5d29b.png)
