### PR TITLE
chore: Set devfile schemaVersion: 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: cpp
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_26_17](https://github.com/che-samples/cpp-hello-world/assets/1271546/865b4341-5672-482f-a927-de100ab399ef)

Related issue: https://github.com/eclipse/che/issues/21985

